### PR TITLE
Fixed small typos

### DIFF
--- a/course/2-chapter-2/sleep.md
+++ b/course/2-chapter-2/sleep.md
@@ -195,7 +195,7 @@ Try getting libc now.
 Now imagine we wanted to know which exports existed in libc. We can do that with the `Module.enumerateExports()` API where `Module` is the resolved module we already had in the previous step. Typically in a script you would do that as follows:
 
 ```javascript
-var libc = Process.getModuleByName("libv-2.30.so");
+var libc = Process.getModuleByName("libc-2.30.so");
 var exports = libc.enumerateExports();
 
 console.log(exports);   // print results

--- a/software/crypt.c
+++ b/software/crypt.c
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
     int access = 0;
     char pin[10];
 
-    while (acces == 0) {
+    while (access == 0) {
         printf("Pin: ");
         fgets(pin, sizeof(pin) - 1, stdin);
         if (test_pin(pin) == 1)


### PR DESCRIPTION
Fixed typo in sleep.md from `libv` to `libc`
Fixed typo in crypt.c (acces to access). Now the code compiles.

Also, the bruteforce code (even tho it's 100% clear and works perfectly) is now covering also the pin `9999` by changing:

```javascript
for (var i = 0; i < 9999; i++) { 
    doStuff()
}
```

to

```javascript
for (var i = 0; i <= 9999; i++) { 
    doStuff()
}
```